### PR TITLE
update

### DIFF
--- a/to do.txt
+++ b/to do.txt
@@ -1,0 +1,3 @@
+ADC_OffsetCenter() : constrain corrected value for 0-4095 to 1-4094 to fix Reicast analog overflow when using evdev.
+
+

--- a/to do.txt
+++ b/to do.txt
@@ -1,3 +1,3 @@
-ADC_OffsetCenter() : constrain corrected value for 0-4095 to 1-4094 to fix Reicast analog overflow when using evdev.
-
+- ADC_OffsetCenter() : constrain corrected value for 0-4095 to 1-4094 to fix Reicast analog overflow when using evdev.
+- Add a debug parameter to output various debug data to dmesg.
 

--- a/to do.txt
+++ b/to do.txt
@@ -1,3 +1,0 @@
-- ADC_OffsetCenter() : constrain corrected value for 0-4095 to 1-4094 to fix Reicast analog overflow when using evdev.
-- Add a debug parameter to output various debug data to dmesg.
-


### PR DESCRIPTION
- debug parameter added to output various debug data to dmesg.
- ADC_OffsetCenter() : constrain corrected value for 0-4095 to 1-4094 to try to fix Reicast analog input overflow when using evdev.
- adc_val default is now 2048 (was 0).